### PR TITLE
More allowed values for metric transform

### DIFF
--- a/statuspage/resource_metric.go
+++ b/statuspage/resource_metric.go
@@ -136,9 +136,9 @@ func resourceMetric() *schema.Resource {
 			"transform": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The transform to apply to metric before pulling into Statuspage. One of: 'average', 'count', 'max', 'min', or 'sum'",
+				Description: "The transform to apply to metric before pulling into Statuspage. One of: 'average', 'count', 'max', 'min', 'sum', 'response_time' or 'uptime'",
 				ValidateFunc: validation.StringInSlice(
-					[]string{"average", "count", "max", "min", "sum"},
+					[]string{"average", "count", "max", "min", "sum", "response_time", "uptime"},
 					false,
 				),
 			},


### PR DESCRIPTION
I was getting 422 error (unfortunately terraform doesn't display details) on pingdom statuspage_metric creation. 

When I was testing manually with `curl` got

`[1] "Transform must be one of response_time|uptime"`

The provider doesn't support it and this PR adds them to allowed list.