### PR TITLE
Support metric_base_uri for newrelic metrics provider

### DIFF
--- a/statuspage/resource_metric_provider.go
+++ b/statuspage/resource_metric_provider.go
@@ -15,6 +15,7 @@ func resourceMetricsProviderCreate(d *schema.ResourceData, m interface{}) error 
 	aPIKey := d.Get("api_key").(string)
 	aPIToken := d.Get("api_token").(string)
 	applicationKey := d.Get("application_key").(string)
+	baseUri := d.Get("metric_base_uri").(string)
 	t := d.Get("type").(string)
 
 	mp, err := sp.CreateMetricsProvider(
@@ -26,6 +27,7 @@ func resourceMetricsProviderCreate(d *schema.ResourceData, m interface{}) error 
 			APIKey:         &aPIKey,
 			APIToken:       &aPIToken,
 			ApplicationKey: &applicationKey,
+			MetricBaseUri:  &baseUri,
 			Type:           &t,
 		},
 	)
@@ -71,6 +73,7 @@ func resourceMetricsProviderUpdate(d *schema.ResourceData, m interface{}) error 
 	aPIKey := d.Get("api_key").(string)
 	aPIToken := d.Get("api_token").(string)
 	applicationKey := d.Get("application_key").(string)
+	baseUri := d.Get("metric_base_uri").(string)
 	t := d.Get("type").(string)
 
 	_, err := sp.UpdateMetricsProvider(
@@ -83,6 +86,7 @@ func resourceMetricsProviderUpdate(d *schema.ResourceData, m interface{}) error 
 			APIKey:         &aPIKey,
 			APIToken:       &aPIToken,
 			ApplicationKey: &applicationKey,
+			MetricBaseUri:  &baseUri,
 			Type:           &t,
 		},
 	)
@@ -147,6 +151,11 @@ func resourceMetricsProvider() *schema.Resource {
 					[]string{"Pingdom", "NewRelic", "Librato", "Datadog", "Self"},
 					false,
 				),
+			},
+			"metric_base_uri": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Required by the NewRelic-type metrics provider",
+				Optional:    true,
 			},
 		},
 	}

--- a/vendor/github.com/yannh/statuspage-go-sdk/metrics_provider.go
+++ b/vendor/github.com/yannh/statuspage-go-sdk/metrics_provider.go
@@ -10,6 +10,7 @@ type MetricsProvider struct {
 	APIKey         *string `json:"api_key,omitempty"`
 	APIToken       *string `json:"api_token,omitempty"`
 	ApplicationKey *string `json:"application_key,omitempty"`
+	MetricBaseUri  *string `json:"metric_base_uri,omitempty"`
 	Type           *string `json:"type,omitempty"`
 }
 
@@ -46,6 +47,9 @@ func (mp *MetricsProvider) validate() error {
 	case "NewRelic":
 		if *mp.APIKey == "" {
 			return fmt.Errorf("parameter api_key is required for NewRelic Metrics Provider")
+		}
+		if *mp.MetricBaseUri == "" {
+			return fmt.Errorf("parameter metric_base_uri is required for NewRelic Metrics Provider")
 		}
 	case "Librato":
 		if *mp.Email == "" {


### PR DESCRIPTION
Statuspage API requires to provide `metric_base_uri` param to create NewRelic-type `metrics_providers`.