### PR TITLE
support api token for pingdom metric provider

### DIFF
--- a/statuspage/resource_metric_provider.go
+++ b/statuspage/resource_metric_provider.go
@@ -155,7 +155,7 @@ func resourceMetricsProvider() *schema.Resource {
 			},
 			"api_token": {
 				Type:        schema.TypeString,
-				Description: "Required by the Librato and Datadog type metrics providers",
+				Description: "Required by the Librato, Pingdom and Datadog type metrics providers",
 				Optional:    true,
 			},
 			"application_key": {

--- a/website/docs/r/statuspage_metrics_provider.html.markdown
+++ b/website/docs/r/statuspage_metrics_provider.html.markdown
@@ -15,9 +15,7 @@ Statuspage metrics provider in the Terraform provider Statuspage.
 ```hcl
 resource "statuspage_metrics_provider" "statuspage_pingdom" {
     page_id         = "pageid"
-    email           = "myemail@provider.com"
-    password        = "pingdom_password"
-    application_key = "pingdomAppKey"
+    api_token       = "a-pingdom-api-token"
     type            = "Pingdom"
 }
 ```
@@ -31,7 +29,7 @@ The following arguments are supported:
  * `email` - Required by the Librato and Pingdom type metrics providers.
  * `password` - Required by the Pingdom-type metrics provider.
  * `api_key` - Required by the Datadog and NewRelic type metrics providers.
- * `api_token` - Required by the Librato type metrics provider.
+ * `api_token` - Required by the Librato and Pingdom-type metrics provider.
  * `application_key` - Required by the Pingdom and Datadog type metrics providers.
 
 ## Import


### PR DESCRIPTION
Pingdom's new API version favors API tokens over credentials. This PR adds support for using pingdom API tokens.

StatusPage UI yields this warning if still using creds:

```
A new API version for Pingdom requires you to reauthenticate before December 1, 2020.
```