### PR TITLE
perform safe deference of transform attr

### DIFF
--- a/statuspage/resource_metric.go
+++ b/statuspage/resource_metric.go
@@ -67,7 +67,11 @@ func resourceMetricRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("name", *metric.Name)
 	d.Set("metric_identifier", *metric.MetricIdentifier)
-	d.Set("transform", *metric.Transform)
+	if metric.Transform != nil {
+		// statuspage.io api does not return transform for GET metric operations
+		// See https://developer.statuspage.io/#operation/getPagesPageIdMetricsMetricId
+		d.Set("transform", *metric.Transform)
+	}
 	d.Set("suffix", *metric.Suffix)
 	d.Set("y_axis_min", *metric.YAxisMin)
 	d.Set("y_axis_max", *metric.YAxisMax)


### PR DESCRIPTION
StatusPage API does not return the `transform` attribute for GET metric operations (See https://developer.statuspage.io/#operation/getPagesPageIdMetricsMetricId). This causes a `nil` deference when fetching a metric.