### PR TITLE
add support for importing resources / passing acc tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ The following attributes are exported:
 
  * automation_email - Email address to send automation events to
 
+### Import Example Usage
+
+```sh
+terraform import statuspage_component.my_component my-page-id/my-component-id
+```
 
 ## statuspage_component_group
 
@@ -66,6 +71,11 @@ The following arguments are supported:
  * name - (Required) name of the component group
  * description - description of the component group
 
+### Import Example Usage
+
+```sh
+terraform import statuspage_component_group.my_group my-page-id/my-component-group-id
+```
 
 ## statuspage_metrics
 
@@ -98,6 +108,11 @@ The following arguments are supported:
  * decimal_places - How many decimal places to render on the graph
  * tooltip_description - A description for the tooltip
 
+### Import Example Usage
+
+```sh
+terraform import statuspage_metric.website_metrics my-page-id/my-metric-id
+```
 
 ## statuspage_metrics_provider
 
@@ -125,6 +140,11 @@ The following arguments are supported:
  * api_token - Required by the Librato type metrics provider.
  * application_key - Required by the Pingdom and Datadog type metrics providers.
 
+### Import Example Usage
+
+```sh
+terraform import statuspage_metrics_provider.statuspage_pingdom my-page-id/my-metrics-provider-id
+```
 
 ## Requirements
 

--- a/statuspage/resource_component.go
+++ b/statuspage/resource_component.go
@@ -1,7 +1,9 @@
 package statuspage
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -107,12 +109,30 @@ func resourceComponentDelete(d *schema.ResourceData, m interface{}) error {
 	return sp.DeleteComponent(client, d.Get("page_id").(string), d.Id())
 }
 
+func resourceComponentImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return []*schema.ResourceData{}, fmt.Errorf("[ERROR] Invalid resource format: %s. Please use 'page-id/component-id'", d.Id())
+	}
+	pageID := strings.Split(d.Id(), "/")[0]
+	componentID := strings.Split(d.Id(), "/")[1]
+	log.Printf("[INFO] Importing Component %s from Page %s", componentID, pageID)
+
+	d.Set("page_id", pageID)
+	d.SetId(componentID)
+	err := resourceComponentRead(d, m)
+
+	return []*schema.ResourceData{d}, err
+}
+
 func resourceComponent() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceComponentCreate,
 		Read:   resourceComponentRead,
 		Update: resourceComponentUpdate,
 		Delete: resourceComponentDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceComponentImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"page_id": {

--- a/statuspage/resource_component_group.go
+++ b/statuspage/resource_component_group.go
@@ -1,7 +1,9 @@
 package statuspage
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	sp "github.com/yannh/statuspage-go-sdk"
@@ -102,12 +104,30 @@ func resourceComponentGroupDelete(d *schema.ResourceData, m interface{}) error {
 	return sp.DeleteComponentGroup(client, d.Get("page_id").(string), d.Id())
 }
 
+func resourceComponentGroupImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return []*schema.ResourceData{}, fmt.Errorf("[ERROR] Invalid resource format: %s. Please use 'page-id/component-group-id'", d.Id())
+	}
+	pageID := strings.Split(d.Id(), "/")[0]
+	componentGroupID := strings.Split(d.Id(), "/")[1]
+	log.Printf("[INFO] Importing Component Group %s from Page %s", componentGroupID, pageID)
+
+	d.Set("page_id", pageID)
+	d.SetId(componentGroupID)
+	err := resourceComponentGroupRead(d, m)
+
+	return []*schema.ResourceData{d}, err
+}
+
 func resourceComponentGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceComponentGroupCreate,
 		Read:   resourceComponentGroupRead,
 		Update: resourceComponentGroupUpdate,
 		Delete: resourceComponentGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceComponentGroupImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"page_id": {

--- a/statuspage/resource_component_group_test.go
+++ b/statuspage/resource_component_group_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccStatuspageComponentGroupBasic(t *testing.T) {
@@ -37,24 +38,24 @@ func TestAccStatuspageComponentGroupBasic(t *testing.T) {
 func TestAccStatuspageComponentGroup_BasicImport(t *testing.T) {
 	rid := acctest.RandIntRange(1000, 9999)
 
-	pageID = fmt.Sprintf("page-id-%d", rid)
-	componentGroupID := rid
-
-	resourceName := "statuspage_component_group.default"
-	importInput := fmt.Sprintf("%s/%d", pageID, componentGroupID)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComponentGroupBasic(rid),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("statuspage_component_group.default", "id"),
+				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportStateId:     importInput,
+				ResourceName:      "statuspage_component_group.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: func(ts *terraform.State) (string, error) {
+					rs := ts.RootModule().Resources["statuspage_component_group.default"]
+					return fmt.Sprintf("%s/%s", pageID, rs.Primary.ID), nil
+				},
 			},
 		},
 	})

--- a/statuspage/resource_component_group_test.go
+++ b/statuspage/resource_component_group_test.go
@@ -34,6 +34,32 @@ func TestAccStatuspageComponentGroupBasic(t *testing.T) {
 	})
 }
 
+func TestAccStatuspageComponentGroup_BasicImport(t *testing.T) {
+	rid := acctest.RandIntRange(1000, 9999)
+
+	pageID = fmt.Sprintf("page-id-%d", rid)
+	componentGroupID := rid
+
+	resourceName := "statuspage_component_group.default"
+	importInput := fmt.Sprintf("%s/%d", pageID, componentGroupID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponentGroupBasic(rid),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     importInput,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComponentGroupBasic(rand int) string {
 	return fmt.Sprintf(`
 	variable "component_name" {

--- a/statuspage/resource_component_test.go
+++ b/statuspage/resource_component_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccStatuspageComponentBasic(t *testing.T) {
@@ -39,24 +40,25 @@ func TestAccStatuspageComponentBasic(t *testing.T) {
 func TestAccStatuspageComponent_BasicImport(t *testing.T) {
 	rid := acctest.RandIntRange(1000, 9999)
 
-	pageID = fmt.Sprintf("page-id-%d", rid)
-	componentID := rid
-
-	resourceName := "statuspage_component.default"
-	importInput := fmt.Sprintf("%s/%d", pageID, componentID)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComponentBasic(rid),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("statuspage_component.default", "id"),
+					resource.TestCheckResourceAttr("statuspage_component.default", "description", "test component"),
+				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportStateId:     importInput,
+				ResourceName:      "statuspage_component.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: func(ts *terraform.State) (string, error) {
+					rs := ts.RootModule().Resources["statuspage_component.default"]
+					return fmt.Sprintf("%s/%s", pageID, rs.Primary.ID), nil
+				},
 			},
 		},
 	})

--- a/statuspage/resource_component_test.go
+++ b/statuspage/resource_component_test.go
@@ -36,6 +36,32 @@ func TestAccStatuspageComponentBasic(t *testing.T) {
 	})
 }
 
+func TestAccStatuspageComponent_BasicImport(t *testing.T) {
+	rid := acctest.RandIntRange(1000, 9999)
+
+	pageID = fmt.Sprintf("page-id-%d", rid)
+	componentID := rid
+
+	resourceName := "statuspage_component.default"
+	importInput := fmt.Sprintf("%s/%d", pageID, componentID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponentBasic(rid),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     importInput,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComponentBasic(rand int) string {
 	return fmt.Sprintf(`
 	variable "name" {

--- a/statuspage/resource_metric_provider.go
+++ b/statuspage/resource_metric_provider.go
@@ -1,7 +1,9 @@
 package statuspage
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -105,12 +107,30 @@ func resourceMetricsProviderDelete(d *schema.ResourceData, m interface{}) error 
 	return sp.DeleteMetricsProvider(client, d.Get("page_id").(string), d.Id())
 }
 
+func resourceMetricsProviderImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return []*schema.ResourceData{}, fmt.Errorf("[ERROR] Invalid resource format: %s. Please use 'page-id/metrics-provider-id'", d.Id())
+	}
+	pageID := strings.Split(d.Id(), "/")[0]
+	metricsProviderID := strings.Split(d.Id(), "/")[1]
+	log.Printf("[INFO] Importing Metrics Provider %s from Page %s", metricsProviderID, pageID)
+
+	d.Set("page_id", pageID)
+	d.SetId(metricsProviderID)
+	err := resourceMetricsProviderRead(d, m)
+
+	return []*schema.ResourceData{d}, err
+}
+
 func resourceMetricsProvider() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceMetricsProviderCreate,
 		Read:   resourceMetricsProviderRead,
 		Update: resourceMetricsProviderUpdate,
 		Delete: resourceMetricsProviderDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceMetricsProviderImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"page_id": {


### PR DESCRIPTION
ok! this is https://github.com/yannh/terraform-provider-statuspage/pull/25 again with patched and passing acceptance tests. Apologies for the poor testing. You were right... we didn't need to re-set the page id. The imported resource id is also now inferred from the previously setup state.

Test patches are e816486e0dbc14d173b8143436fdfe3823216b00 and 10e7b746318b53b5615e60d7371acfe7977dbefa.
