### PR TITLE
Adding Sensitive flag to metric provider fields

### DIFF
--- a/statuspage/resource_metric_provider.go
+++ b/statuspage/resource_metric_provider.go
@@ -147,21 +147,25 @@ func resourceMetricsProvider() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Required by the Pingdom-type metrics provider",
 				Optional:    true,
+				Sensitive:   true,
 			},
 			"api_key": {
 				Type:        schema.TypeString,
 				Description: "Required by the Datadog and NewRelic type metrics providers",
 				Optional:    true,
+				Sensitive:   true,
 			},
 			"api_token": {
 				Type:        schema.TypeString,
 				Description: "Required by the Librato and Datadog type metrics providers",
 				Optional:    true,
+				Sensitive:   true,
 			},
 			"application_key": {
 				Type:        schema.TypeString,
 				Description: "Required by the Pingdom-type metrics provider",
 				Optional:    true,
+				Sensitive:   true,
 			},
 			"type": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Thank you very much for your work on this provider, it's really helpful.

According to Terraform best practices when a field is likely to contain sensitive information it is best to set the 'Sensitive' property to true, see: https://www.terraform.io/docs/extend/best-practices/sensitive-state.html.

We have a use case where we don't want the metric provider to be displayed during terraform plan and apply, this change allows for the the secrets to be replaced with "(sensitive value)".

Only setting 'Sensitive' flag on metric provider field containing secrets.