### PR TITLE
Component: Allow dynamic status

### DIFF
--- a/statuspage/resource_component.go
+++ b/statuspage/resource_component.go
@@ -29,7 +29,7 @@ func resourceComponentCreate(d *schema.ResourceData, m interface{}) error {
 			Name:               &name,
 			Description:        &description,
 			OnlyShowIfDegraded: &onlyShowIfDegraded,
-			Status:             &status,
+			Status:             status,
 			Showcase:           &showcase,
 		},
 	)
@@ -89,7 +89,7 @@ func resourceComponentUpdate(d *schema.ResourceData, m interface{}) error {
 			Name:               &name,
 			Description:        &description,
 			OnlyShowIfDegraded: &onlyShowIfDegraded,
-			Status:             &status,
+			Status:             status,
 			Showcase:           &showcase,
 		},
 	)
@@ -158,7 +158,12 @@ func resourceComponent() *schema.Resource {
 					[]string{"operational", "under_maintenance", "degraded_performance", "partial_outage", "major_outage", ""},
 					false,
 				),
-				Default: "operational",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if new == "" || old == new {
+						return true
+					}
+					return false
+				},
 			},
 			"only_show_if_degraded": {
 				Type:        schema.TypeBool,

--- a/vendor/github.com/yannh/statuspage-go-sdk/component.go
+++ b/vendor/github.com/yannh/statuspage-go-sdk/component.go
@@ -5,7 +5,7 @@ type Component struct {
 	Description        *string `json:"description,omitempty"`
 	GroupID            *string `json:"group_id,omitempty"`
 	Showcase           *bool   `json:"showcase,omitempty"`
-	Status             *string `json:"status,omitempty"`
+	Status             string  `json:"status,omitempty"`
 	OnlyShowIfDegraded *bool   `json:"only_show_if_degraded,omitempty"`
 }
 


### PR DESCRIPTION
In some cases we want the component status to be dynamic, e.g. when updating status automatically from Opsgenie using service metrics.
Current setup is problematic because `terraform apply` always resets the status to the one in the manifest and sets it to `operational` if omitted or set to empty (is this a bug?). So we always have to wait for all components to be operational before we can do `terraform apply`.

In this PR I made the status optional, so if status is omitted or set to empty string it will not trigger any state changes.