### PR TITLE
issue#51: Added component start_date

### DIFF
--- a/statuspage/resource_component.go
+++ b/statuspage/resource_component.go
@@ -3,6 +3,7 @@ package statuspage
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -22,6 +23,7 @@ func resourceComponentCreate(d *schema.ResourceData, m interface{}) error {
 	onlyShowIfDegraded := d.Get("only_show_if_degraded").(bool)
 	status := d.Get("status").(string)
 	showcase := d.Get("showcase").(bool)
+	startDate := d.Get("start_date").(string)
 
 	component, err := sp.CreateComponent(
 		client, d.Get("page_id").(string),
@@ -31,6 +33,7 @@ func resourceComponentCreate(d *schema.ResourceData, m interface{}) error {
 			OnlyShowIfDegraded: &onlyShowIfDegraded,
 			Status:             &status,
 			Showcase:           &showcase,
+			StartDate:          &startDate,
 		},
 	)
 	if err != nil {
@@ -66,6 +69,7 @@ func resourceComponentRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("status", component.Status)
 	d.Set("showcase", component.Showcase)
 	d.Set("automation_email", component.AutomationEmail)
+	d.Set("start_date", component.StartDate)
 
 	return nil
 }
@@ -79,6 +83,7 @@ func resourceComponentUpdate(d *schema.ResourceData, m interface{}) error {
 	onlyShowIfDegraded := d.Get("only_show_if_degraded").(bool)
 	status := d.Get("status").(string)
 	showcase := d.Get("showcase").(bool)
+	startDate := d.Get("start_date").(string)
 
 	_, err := sp.UpdateComponent(
 		client,
@@ -90,6 +95,7 @@ func resourceComponentUpdate(d *schema.ResourceData, m interface{}) error {
 			OnlyShowIfDegraded: &onlyShowIfDegraded,
 			Status:             &status,
 			Showcase:           &showcase,
+			StartDate:          &startDate,
 		},
 	)
 	if err != nil {
@@ -176,6 +182,15 @@ func resourceComponent() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Email address to send automation events to",
 				Computed:    true,
+			},
+			"start_date": {
+				Type:        schema.TypeString,
+				Description: "Start date of component",
+				Optional:    true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("(^(19|20)[0-9]{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$)?"),
+					"A valid date must be supplied in the format yyyy-mm-dd",
+				),
 			},
 		},
 	}

--- a/statuspage/resource_component.go
+++ b/statuspage/resource_component.go
@@ -11,29 +11,47 @@ import (
 	sp "github.com/yannh/statuspage-go-sdk"
 )
 
+func b(b bool) *bool {
+	return &b
+}
+
 func s(s string) *string {
 	return &s
+}
+
+func getOptionalBool(d *schema.ResourceData, key string) *bool {
+	if value, ok := d.GetOk(key); ok {
+		return b(value.(bool))
+	}
+	return nil
+}
+
+func getOptionalString(d *schema.ResourceData, key string) *string {
+	if value, ok := d.GetOk(key); ok {
+		return s(value.(string))
+	}
+	return nil
 }
 
 func resourceComponentCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*sp.Client)
 
-	name := d.Get("name").(string)
-	description := d.Get("description").(string)
-	onlyShowIfDegraded := d.Get("only_show_if_degraded").(bool)
-	status := d.Get("status").(string)
-	showcase := d.Get("showcase").(bool)
-	startDate := d.Get("start_date").(string)
+	name := s(d.Get("name").(string))
+	description := getOptionalString(d, "description")
+	onlyShowIfDegraded := getOptionalBool(d, "only_show_if_degraded")
+	status := getOptionalString(d, "status")
+	showcase := getOptionalBool(d, "showcase")
+	startDate := getOptionalString(d, "start_date")
 
 	component, err := sp.CreateComponent(
 		client, d.Get("page_id").(string),
 		&sp.Component{
-			Name:               &name,
-			Description:        &description,
-			OnlyShowIfDegraded: &onlyShowIfDegraded,
-			Status:             &status,
-			Showcase:           &showcase,
-			StartDate:          &startDate,
+			Name:               name,
+			Description:        description,
+			OnlyShowIfDegraded: onlyShowIfDegraded,
+			Status:             status,
+			Showcase:           showcase,
+			StartDate:          startDate,
 		},
 	)
 	if err != nil {
@@ -78,24 +96,24 @@ func resourceComponentUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*sp.Client)
 	componentID := d.Id()
 
-	name := d.Get("name").(string)
-	description := d.Get("description").(string)
-	onlyShowIfDegraded := d.Get("only_show_if_degraded").(bool)
-	status := d.Get("status").(string)
-	showcase := d.Get("showcase").(bool)
-	startDate := d.Get("start_date").(string)
+	name := s(d.Get("name").(string))
+	description := getOptionalString(d, "description")
+	onlyShowIfDegraded := getOptionalBool(d, "only_show_if_degraded")
+	status := getOptionalString(d, "status")
+	showcase := getOptionalBool(d, "showcase")
+	startDate := getOptionalString(d, "start_date")
 
 	_, err := sp.UpdateComponent(
 		client,
 		d.Get("page_id").(string),
 		componentID,
 		&sp.Component{
-			Name:               &name,
-			Description:        &description,
-			OnlyShowIfDegraded: &onlyShowIfDegraded,
-			Status:             &status,
-			Showcase:           &showcase,
-			StartDate:          &startDate,
+			Name:               name,
+			Description:        description,
+			OnlyShowIfDegraded: onlyShowIfDegraded,
+			Status:             status,
+			Showcase:           showcase,
+			StartDate:          startDate,
 		},
 	)
 	if err != nil {

--- a/statuspage/resource_component_group_test.go
+++ b/statuspage/resource_component_group_test.go
@@ -76,6 +76,7 @@ func testAccComponentGroupBasic(rand int) string {
 		name = "${var.component_name}_component"
 		description = "test component"
 		status = "operational"
+		start_date = "2023-01-01"
 	}
 
 	resource "statuspage_component_group" "default" {
@@ -102,6 +103,7 @@ func testAccComponentGroupUpdate(rand int) string {
 		name = "${var.component_name}_component"
 		description = "test component"
 		status = "operational"
+		start_date = "2023-01-01"
 	}
 
 	resource "statuspage_component" "comp2" {
@@ -109,6 +111,7 @@ func testAccComponentGroupUpdate(rand int) string {
 		name = "${var.component_name}_component"
 		description = "test component"
 		status = "operational"
+		start_date = "2023-01-01"
 	}
 
 	resource "statuspage_component" "comp3" {
@@ -116,6 +119,7 @@ func testAccComponentGroupUpdate(rand int) string {
 		name = "${var.component_name}_component"
 		description = "test component"
 		status = "operational"
+		start_date = "2023-01-01"
 	}
 
 	resource "statuspage_component" "comp4" {
@@ -123,6 +127,7 @@ func testAccComponentGroupUpdate(rand int) string {
 		name = "${var.component_name}_component"
 		description = "test component"
 		status = "operational"
+		start_date = "2023-01-01"
 	}
 
 	resource "statuspage_component_group" "default" {

--- a/statuspage/resource_component_test.go
+++ b/statuspage/resource_component_test.go
@@ -22,6 +22,7 @@ func TestAccStatuspageComponentBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("statuspage_component.default", "description", "test component"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "status", "operational"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "showcase", "true"),
+					resource.TestCheckResourceAttr("statuspage_component.default", "start_date", "2023-01-01"),
 				),
 			},
 			{
@@ -31,6 +32,7 @@ func TestAccStatuspageComponentBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("statuspage_component.default", "description", "updated component"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "status", "major_outage"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "showcase", "false"),
+					resource.TestCheckResourceAttr("statuspage_component.default", "start_date", "2023-01-01"),
 				),
 			},
 		},
@@ -51,6 +53,7 @@ func TestAccStatuspageComponentBasicPageIDUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuspage_component.default", "description", "test component"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "status", "operational"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "showcase", "true"),
+					resource.TestCheckResourceAttr("statuspage_component.default", "start_date", "2023-01-01"),
 				),
 			},
 			{
@@ -61,6 +64,7 @@ func TestAccStatuspageComponentBasicPageIDUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuspage_component.default", "description", "updated component"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "status", "major_outage"),
 					resource.TestCheckResourceAttr("statuspage_component.default", "showcase", "false"),
+					resource.TestCheckResourceAttr("statuspage_component.default", "start_date", "2023-01-01"),
 				),
 			},
 		},
@@ -110,6 +114,7 @@ func testAccComponentBasic(rand int) string {
 		description = "test component"
 		status = "operational"
 		showcase = true
+		start_date = "2023-01-01"
 	}
 	`, rand, pageID)
 }
@@ -130,6 +135,7 @@ func testAccComponentUpdate(rand int) string {
 		description = "updated component"
 		status = "major_outage"
 		showcase = false
+		start_date = "2023-01-01"
 	}
 	`, rand, pageID)
 }
@@ -150,6 +156,7 @@ func testAccComponentUpdatePageID(rand int) string {
 		description = "updated component"
 		status = "major_outage"
 		showcase = false
+		start_date = "2023-01-01"
 	}
 	`, rand, pageID2)
 }

--- a/vendor/github.com/yannh/statuspage-go-sdk/component.go
+++ b/vendor/github.com/yannh/statuspage-go-sdk/component.go
@@ -7,6 +7,7 @@ type Component struct {
 	Showcase           *bool   `json:"showcase,omitempty"`
 	Status             *string `json:"status,omitempty"`
 	OnlyShowIfDegraded *bool   `json:"only_show_if_degraded,omitempty"`
+	StartDate          *string `json:"start_date,omitempty"`
 }
 
 type ComponentFull struct {
@@ -17,6 +18,7 @@ type ComponentFull struct {
 	CreatedAt       *string `json:"created_at"`
 	UpdatedAt       *string `json:"updated_at"`
 	AutomationEmail *string `json:"automation_email"`
+	StartDate       *string `json:"start_date,omitempty"`
 }
 
 func CreateComponent(client *Client, pageID string, component *Component) (*ComponentFull, error) {


### PR DESCRIPTION
This is to add back support for start_date as mentioned on issue https://github.com/yannh/terraform-provider-statuspage/issues/51

What seemed to have happened was that `d.Get` returns the default value of the type if it's not present on the configuration, so because the start date was not set into the tests, it was being sent as an empty string instead of nil and the api didn't like that.

I switched to using `d.GetOk` on the optional fields which also returns if the value exists on the configuration so we can set the field to nil if it doesn't exist.
This should also fix another issue I have found where I tried to import a third party component and omit the status field, but it would override it to "operational" which was setting the override flag on the status page.