### PR TITLE
Enable testing of statuspage_metric and checking of null metric attributes on read operations

### DIFF
--- a/statuspage/resource_metric.go
+++ b/statuspage/resource_metric.go
@@ -74,13 +74,26 @@ func resourceMetricRead(d *schema.ResourceData, m interface{}) error {
 		// See https://developer.statuspage.io/#operation/getPagesPageIdMetricsMetricId
 		d.Set("transform", *metric.Transform)
 	}
-	d.Set("suffix", *metric.Suffix)
-	d.Set("y_axis_min", *metric.YAxisMin)
-	d.Set("y_axis_max", *metric.YAxisMax)
-	d.Set("y_axis_hidden", *metric.YAxisHidden)
-	d.Set("display", *metric.Display)
-	d.Set("decimal_places", *metric.DecimalPlaces)
 
+	// statuspage.io api does not return default values for these fields if they are not initially set
+	if metric.Suffix != nil {
+		d.Set("suffix", *metric.Suffix)
+	}
+	if metric.YAxisMin != nil {
+		d.Set("y_axis_min", *metric.YAxisMin)
+	}
+	if metric.YAxisMax != nil {
+		d.Set("y_axis_max", *metric.YAxisMax)
+	}
+	if metric.YAxisHidden != nil {
+		d.Set("y_axis_hidden", *metric.YAxisHidden)
+	}
+	if metric.Display != nil {
+		d.Set("display", *metric.Display)
+	}
+	if metric.DecimalPlaces != nil {
+		d.Set("decimal_places", *metric.DecimalPlaces)
+	}
 	if metric.TooltipDescription != nil {
 		d.Set("tooltip_description", *metric.TooltipDescription)
 	}

--- a/statuspage/resource_metric_provider.go
+++ b/statuspage/resource_metric_provider.go
@@ -179,7 +179,7 @@ func resourceMetricsProvider() *schema.Resource {
 			},
 			"metric_base_uri": &schema.Schema{
 				Type:        schema.TypeString,
-				Description: "Required by the NewRelic-type metrics provider",
+				Description: "Required by the Datadog and NewRelic-type metrics provider",
 				Optional:    true,
 			},
 		},

--- a/statuspage/resource_metric_test.go
+++ b/statuspage/resource_metric_test.go
@@ -47,11 +47,11 @@ func testAccMetricBasic() string {
 		metric_base_uri = "https://app.datadoghq.com/api/v1"
 	}
 
-	#resource "statuspage_metric" "datadog_metric" {
-	#	page_id             = "${var.pageid}"
-	#	metrics_provider_id = "${statuspage_metrics_provider.datadog.id}"
-	#	name                = "Forum"
-	#	metric_identifier   = "sum:apache.net.request_per_s{project:forum}"
-	#}
+	resource "statuspage_metric" "datadog_metric" {
+		page_id             = "${var.pageid}"
+		metrics_provider_id = "${statuspage_metrics_provider.datadog.id}"
+		name                = "DataDog Agent Started"
+		metric_identifier   = "avg:datadog.agent.started{*}.as_count()"
+	}
 	`, pageID, os.Getenv("DATADOG_API_KEY"), os.Getenv("DATADOG_APPLICATION_KEY"))
 }


### PR DESCRIPTION
Adding null checks to the metric resource, since the resource will fail on a null pointer reference without it.
This is because the Atlassian StatusPage API does not return default values for these non-required fields if they are not set at creation.

I also added to the description of `metric_base_uri` parameter of the `metric_provider` resource, since it is required for Datadog type metric providers. 

I also re-enabled the `statuspage_metric` test with what I believe as a default DataDog metric.
I do have access to a DataDog account with metrics, so I can help collaborate on testing and development related to DataDog related resources on the project. 